### PR TITLE
feat: use telescope-live-grep-args so that args can be used in grep

### DIFF
--- a/lazy-lock.json
+++ b/lazy-lock.json
@@ -34,6 +34,7 @@
   "onedark.nvim": { "branch": "master", "commit": "fae34f7c635797f4bf62fb00e7d0516efa8abe37" },
   "plenary.nvim": { "branch": "master", "commit": "2d9b06177a975543726ce5c73fca176cedbffe9d" },
   "telescope-file-browser.nvim": { "branch": "master", "commit": "3b8a1e17187cfeedb31decbd625da62398a8ff34" },
+  "telescope-live-grep-args.nvim": { "branch": "master", "commit": "8ad632f793fd437865f99af5684f78300dac93fb" },
   "telescope-zf-native.nvim": { "branch": "master", "commit": "5721be27df11a19b9cd95e6a4887f16f26599802" },
   "telescope.nvim": { "branch": "master", "commit": "7011eaae0ac1afe036e30c95cf80200b8dc3f21a" },
   "todo-comments.nvim": { "branch": "main", "commit": "ae0a2afb47cf7395dc400e5dc4e05274bf4fb9e0" },

--- a/lua/wangleng/plugins/navigation.lua
+++ b/lua/wangleng/plugins/navigation.lua
@@ -24,10 +24,16 @@ return {
                     live_grep_args = {
                         mappings = {
                             i = {
+                                -- wrap text with quotes
                                 ["<C-k>"] = lga_actions.quote_prompt(),
-                                ["<C-i>"] = lga_actions.quote_prompt({ postfix = " -s " }),
+                                -- wrap text with quotes + case insensitive
+                                ["<C-i>"] = lga_actions.quote_prompt({ postfix = " -i " }),
+                                -- wrap text with quotes + limit to files (via glob regex syntax)
                                 ["<C-d>"] = lga_actions.quote_prompt({ postfix = " --iglob " }),
+                                -- wrap text with quotes + disable regex
                                 ["<C-f>"] = lga_actions.quote_prompt({ postfix = " -F " }),
+                                -- wrap text with quotes + enforce case sensitive
+                                ["<C-u>"] = lga_actions.quote_prompt({ postfix = " -s " }),
                                 -- freeze the current list and start a fuzzy search in the frozen list
                                 ["<C-space>"] = lga_actions.to_fuzzy_refine,
                             }

--- a/lua/wangleng/plugins/navigation.lua
+++ b/lua/wangleng/plugins/navigation.lua
@@ -3,9 +3,40 @@ return {
     {
         'nvim-telescope/telescope.nvim',
         tag = '0.1.4',
-        dependencies = { 'nvim-lua/plenary.nvim', 'nvim-tree/nvim-web-devicons' },
+        dependencies = {
+            'nvim-lua/plenary.nvim',
+            'nvim-tree/nvim-web-devicons',
+
+            -- extra extensions
+            {
+                "nvim-telescope/telescope-live-grep-args.nvim",
+                -- This will not install any breaking changes.
+                -- For major updates, this must be adjusted manually.
+                version = "^1.0.0",
+            }
+        },
         config = function()
-            require('telescope').setup()
+            local telescope = require('telescope')
+            local lga_actions = require('telescope-live-grep-args.actions')
+
+            telescope.setup({
+                extensions = {
+                    live_grep_args = {
+                        mappings = {
+                            i = {
+                                ["<C-k>"] = lga_actions.quote_prompt(),
+                                ["<C-i>"] = lga_actions.quote_prompt({ postfix = " -s " }),
+                                ["<C-d>"] = lga_actions.quote_prompt({ postfix = " --iglob " }),
+                                ["<C-f>"] = lga_actions.quote_prompt({ postfix = " -F " }),
+                                -- freeze the current list and start a fuzzy search in the frozen list
+                                ["<C-space>"] = lga_actions.to_fuzzy_refine,
+                            }
+                        }
+                    }
+                }
+            })
+            telescope.load_extension('live_grep_args')
+
             local keyset = vim.keymap.set
 
             local project_files = function()
@@ -24,14 +55,19 @@ return {
 
             -- additional: live grep
             keyset("n", "<leader>f", function()
-                require "telescope.builtin".live_grep({
+                require "telescope".extensions.live_grep_args.live_grep_args({
                     layout_strategy = 'vertical',
                 })
             end, { silent = true })
 
             -- additional: search word under cursor
             keyset("n", "<leader>F", function()
-                require "telescope.builtin".grep_string({
+                require "telescope-live-grep-args.shortcuts".grep_word_under_cursor({
+                    layout_strategy = 'vertical',
+                })
+            end, { silent = true })
+            keyset("v", "<leader>F", function()
+                require "telescope-live-grep-args.shortcuts".grep_visual_selection({
                     layout_strategy = 'vertical',
                 })
             end, { silent = true })


### PR DESCRIPTION
Fixes #43.

The use of mappings is actually pretty awesome.

```lua
                        mappings = {
                            i = {
                                ["<C-k>"] = lga_actions.quote_prompt(),
                                ["<C-i>"] = lga_actions.quote_prompt({ postfix = " -s " }),
                                ["<C-d>"] = lga_actions.quote_prompt({ postfix = " --iglob " }),
                                ["<C-f>"] = lga_actions.quote_prompt({ postfix = " -F " }),
                                -- freeze the current list and start a fuzzy search in the frozen list
                                ["<C-space>"] = lga_actions.to_fuzzy_refine,
                            }
                        }
```