### PR TITLE
chore: remove vim-commentary, use neovim built-in commentary instead

### DIFF
--- a/lazy-lock.json
+++ b/lazy-lock.json
@@ -39,7 +39,6 @@
   "telescope.nvim": { "branch": "master", "commit": "7011eaae0ac1afe036e30c95cf80200b8dc3f21a" },
   "todo-comments.nvim": { "branch": "main", "commit": "ae0a2afb47cf7395dc400e5dc4e05274bf4fb9e0" },
   "tokyonight.nvim": { "branch": "main", "commit": "2c85fad417170d4572ead7bf9fdd706057bd73d7" },
-  "vim-commentary": { "branch": "master", "commit": "c4b8f52cbb7142ec239494e5a2c4a512f92c4d07" },
   "vim-fugitive": { "branch": "master", "commit": "d4877e54cef67f5af4f950935b1ade19ed6b7370" },
   "vim-surround": { "branch": "master", "commit": "3d188ed2113431cf8dac77be61b842acb64433d9" },
   "vscode.nvim": { "branch": "main", "commit": "7de58b7a6d55fe48475d0ba2fddbcec871717761" }

--- a/lua/wangleng/plugins/editing.lua
+++ b/lua/wangleng/plugins/editing.lua
@@ -30,6 +30,4 @@ return {
     },
     -- tpope: surround
     'tpope/vim-surround',
-    -- tpope: comment
-    'tpope/vim-commentary',
 }


### PR DESCRIPTION
The built-in commentary functions are available since neovim v0.10.0, and the shortcuts are the same (e.g. `gcc`). See:
https://github.com/neovim/neovim/pull/28176.

The variations were investigated and we are ok with it. See our report at: https://github.com/yamgent/mynvim/issues/44.

Fixes #44.