### PR TITLE
fix: switch telescope grep quick postfix to <C-c>

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -48,7 +48,7 @@ In `~/.config/simple-settings/settings.json`
 Useful for cases where the project may have a standard set of ignores for
 example.
 
-Access the quick postfix with `<C-p>` when telescope grep is active.
+Access the quick postfix with `<C-c>` when telescope grep is active.
 
 In `~/.config/simple-settings/settings.json`
 

--- a/lua/wangleng/plugins/navigation.lua
+++ b/lua/wangleng/plugins/navigation.lua
@@ -43,7 +43,7 @@ return {
                                 -- freeze the current list and start a fuzzy search in the frozen list
                                 ["<C-space>"] = lga_actions.to_fuzzy_refine,
                                 -- customizable quick postfix
-                                ["<C-p>"] = lga_actions.quote_prompt({ postfix = telescope_grep_quick_postfix }),
+                                ["<C-c>"] = lga_actions.quote_prompt({ postfix = telescope_grep_quick_postfix }),
                             }
                         }
                     }


### PR DESCRIPTION
`<C-p>` is normally used to go to previous entry in the search list while in insert mode. We use this quite frequently, so it is bad to override the shortcut with quick postfix.

`<C-c>` on the other hand, is less used. `<C-c>` automatically quits the search window, but we usually just use `<Esc><Esc>` to do that, instead of `<C-c>`. So it is an acceptable override.